### PR TITLE
More improvements to package building

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ When `PACKAGECLOUD_REPOSITORY` is set to `test`:
 
   - Changes to `debian/changelog` are committed to a temporary branch.
   - A debian git tag is created (eg. `debian/${tag}-linz~${DISTRIBUTION}`).
-  - The debian tag is merged to any local and remote branch containing the
-    initial HEAD reference of the source tree.
-  - The debian tag is pushed to any remote having branches containing the
+  - The debian tag is merged to any local and remote branch pointing
+    at the initial HEAD reference of the source tree.
+  - The debian tag is pushed to any remote having branches pointing at the
     initial HEAD reference of the source tree and to any remote passed
     via the `PUSH_TO_GIT_REMOTE` env variable.
 

--- a/README.md
+++ b/README.md
@@ -54,13 +54,17 @@ On success, the packages will be also found on:
 
 When `PUBLISH_TO_REPOSITORY` is set to `test`:
 
-  - Changes to `debian/changelog` are committed in a temporary branch.
-  - A debian tag is created (eg. `debian/${tag}-linz~${DISTRIBUTION}`).
+  - Changes to `debian/changelog` are committed to a temporary branch.
+  - A debian git tag is created (eg. `debian/${tag}-linz~${DISTRIBUTION}`).
+  - The debian tag is merged to any local and remote branch containing the
+    initial HEAD reference of the source tree.
+  - The debian tag is pushed to any remote having branches containing the
+    initial HEAD reference of the source tree and to any remote passed
+    via the `PUSH_TO_GIT_REMOTE` env variable.
 
-  If any remote branch containing the HEAD reference in the source tree
-  is found, or you pass a remote url/name via `PUSH_TO_GIT_REMOTE` env
-  variable, then the debian tag is pushed to each remote. Changes are
-  pushed to each remote branch as well. Example:
+Passing a `PUSH_TO_GIT_REMOTE` env variable is useful to specify
+credentials to access the remote (as the docker container will not
+have access to those). Example:
 
     export PUBLISH_TO_REPOSITORY="test"
     export PACKAGECLOUD_TOKEN # set to API token
@@ -70,12 +74,6 @@ When `PUBLISH_TO_REPOSITORY` is set to `test`:
            -e PACKAGECLOUD_TOKEN \
            -e PUSH_TO_GIT_REMOTE \
            linz-deb-builder:${DISTRIBUTION}
-
-If no remote branch is found, you will probably want to merge the work done
-during packaging back to your working branch manually.  You can do so with
-something like the following:
-
-    git merge --ff-only ${tag} # tag is printed in output
 
 If you only want to test the image without triggering any changes
 to any remote (packagecloud and git remotes) you can pass the `DRY_RUN`

--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ something like the following:
 
     git merge --ff-only ${tag} # tag is printed in output
 
+If you only want to test the image without triggering any changes
+to any remote (packagecloud and git remotes) you can pass the `DRY_RUN`
+environment variable with any non-empty string:
+
+    export PUBLISH_TO_REPOSITORY="test"
+    export PACKAGECLOUD_TOKEN # set to API token
+    export PUSH_TO_GIT_REMOTE=https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
+    docker run --rm -v $(pwd):/pkg \
+           -e PUBLISH_TO_REPOSITORY \
+           -e PACKAGECLOUD_TOKEN \
+           -e PUSH_TO_GIT_REMOTE \
+           -e DRY_RUN=yes \
+           linz-deb-builder:${DISTRIBUTION}
+
 ## Use of the github action
 
 If you want a github workflow to take care of building packages

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ For example:
 
     steps:
     - uses: actions/checkout@v1
-    - uses: linz/linz-software-repository@v3
+    - uses: linz/linz-software-repository@v4
 
 The default action only builds the packages.
 
@@ -108,7 +108,7 @@ you'll need to pass appropriate parameters:
 
     steps:
     - uses: actions/checkout@v1
-    - uses: linz/linz-software-repository@v3
+    - uses: linz/linz-software-repository@v4
       with:
         packagecloud_token: ${{ secrets.PACKAGECLOUD_TOKEN }}
         publish_to_repository: 'dev'
@@ -121,7 +121,7 @@ to set the "origin" url to have credentials:
     - name: Authorize pushing to remote
       run: |
         git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}
-    - uses: linz/linz-software-repository@v3
+    - uses: linz/linz-software-repository@v4
       with:
         packagecloud_token: ${{ secrets.PACKAGECLOUD_TOKEN }}
         publish_to_repository: 'test'

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ On success, the packages will be also found on:
 When `PUBLISH_TO_REPOSITORY` is set to `test`:
 
   - Changes to `debian/changelog` are committed in a temporary branch.
-  - A debian tag is created (`debian/${tag}linz_${repo}1`).
+  - A debian tag is created (eg. `debian/${tag}-linz~${DISTRIBUTION}`).
 
   If any remote branch containing the HEAD reference in the source tree
   is found, or you pass a remote url/name via `PUSH_TO_GIT_REMOTE` env
-  variable, then changes are pushed to each corresponding remote branch
-  and tag is pushed to each unique remote. Example:
+  variable, then the debian tag is pushed to each remote. Changes are
+  pushed to each remote branch as well. Example:
 
     export PUBLISH_TO_REPOSITORY="test"
     export PACKAGECLOUD_TOKEN # set to API token

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ When `PUBLISH_TO_REPOSITORY` is set to `test`:
   - Changes to `debian/changelog` are committed in a temporary branch.
   - A debian tag is created (`debian/${tag}linz_${repo}1`).
 
-  If a remote branch containing the HEAD reference in the source tree
+  If any remote branch containing the HEAD reference in the source tree
   is found, or you pass a remote url/name via `PUSH_TO_GIT_REMOTE` env
-  variable, then both the tag and changes are pushed to corresponding
-  branch and remote. Example:
+  variable, then changes are pushed to each corresponding remote branch
+  and tag is pushed to each unique remote. Example:
 
     export PUBLISH_TO_REPOSITORY="test"
     export PACKAGECLOUD_TOKEN # set to API token

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ directory of the source tree.
 If you also want packages to be published to linz repository, pass
 packagecloud token and target repository as environment variables:
 
-    export PUBLISH_TO_REPOSITORY=dev # or "test"
+    export PACKAGECLOUD_REPOSITORY=dev # or "test"
     export PACKAGECLOUD_TOKEN # set to API token
     docker run --rm -v $(pwd):/pkg \
-           -e PUBLISH_TO_REPOSITORY \
+           -e PACKAGECLOUD_REPOSITORY \
            -e PACKAGECLOUD_TOKEN \
            linz-deb-builder:${DISTRIBUTION}
 
@@ -52,7 +52,7 @@ On success, the packages will be also found on:
 
     https://packagecloud.io/linz/${repo}
 
-When `PUBLISH_TO_REPOSITORY` is set to `test`:
+When `PACKAGECLOUD_REPOSITORY` is set to `test`:
 
   - Changes to `debian/changelog` are committed to a temporary branch.
   - A debian git tag is created (eg. `debian/${tag}-linz~${DISTRIBUTION}`).
@@ -66,11 +66,11 @@ Passing a `PUSH_TO_GIT_REMOTE` env variable is useful to specify
 credentials to access the remote (as the docker container will not
 have access to those). Example:
 
-    export PUBLISH_TO_REPOSITORY="test"
+    export PACKAGECLOUD_REPOSITORY="test"
     export PACKAGECLOUD_TOKEN # set to API token
     export PUSH_TO_GIT_REMOTE=https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
     docker run --rm -v $(pwd):/pkg \
-           -e PUBLISH_TO_REPOSITORY \
+           -e PACKAGECLOUD_REPOSITORY \
            -e PACKAGECLOUD_TOKEN \
            -e PUSH_TO_GIT_REMOTE \
            linz-deb-builder:${DISTRIBUTION}
@@ -79,11 +79,11 @@ If you only want to test the image without triggering any changes
 to any remote (packagecloud and git remotes) you can pass the `DRY_RUN`
 environment variable with any non-empty string:
 
-    export PUBLISH_TO_REPOSITORY="test"
+    export PACKAGECLOUD_REPOSITORY="test"
     export PACKAGECLOUD_TOKEN # set to API token
     export PUSH_TO_GIT_REMOTE=https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
     docker run --rm -v $(pwd):/pkg \
-           -e PUBLISH_TO_REPOSITORY \
+           -e PACKAGECLOUD_REPOSITORY \
            -e PACKAGECLOUD_TOKEN \
            -e PUSH_TO_GIT_REMOTE \
            -e DRY_RUN=yes \

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   packagecloud_token:
     description: 'Package Cloud API Token'
     required: false
-  publish_to_repository:
+  packagecloud_repository:
     description: 'Package Cloud repository to publish to (dev|test)'
     required: false
     default: ''
@@ -27,6 +27,6 @@ runs:
     - ${{ inputs.repo }}
   env:
     PACKAGECLOUD_TOKEN: '${{ inputs.packagecloud_token }}'
-    PUBLISH_TO_REPOSITORY: '${{ inputs.publish_to_repository }}'
+    PACKAGECLOUD_REPOSITORY: '${{ inputs.packagecloud_repository }}'
     PUSH_TO_GIT_REMOTE: '${{ inputs.push_to_git_remote }}'
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -247,9 +247,9 @@ if test -n "${GIT_TAG}"; then
         continue
       fi
 
-      echo " Merging tag '${GIT_TAG}' to head '${HEAD}'"
-      echo "git push ${GIT_DRY_RUN} . 'refs/tags/${GIT_TAG}':'${HEAD}'"
-      git push ${GIT_DRY_RUN} . "refs/tags/${GIT_TAG}":"${HEAD}" || exit 1
+      echo " Merging temporary branch to head '${HEAD}'"
+      echo "git push ${GIT_DRY_RUN} . '${TMPBRANCH}':'${HEAD}'"
+      git push ${GIT_DRY_RUN} . "${TMPBRANCH}":"${HEAD}" || exit 1
 
     elif expr "$REF" : remotes/ > /dev/null; then
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -251,7 +251,7 @@ if test -n "${GIT_TAG}"; then
   done
 
   echo "--------------------------------------------------"
-  echo "Remotes to push to: $(cat ${REMOTES_FILE} | printurl | tr '\n' ' ')"
+  echo "Remotes to push tag to: $(cat ${REMOTES_FILE} | printurl | tr '\n' ' ')"
   echo "--------------------------------------------------"
 
   while read -r PUSH_TO; do

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -193,19 +193,18 @@ ls -l build-area/*.deb
 if test -n "${PACKAGECLOUD_REPOSITORY}"; then
 
   echo "--------------------------------------------------"
-  echo "Publishing packages to packagecloud ${REPO}"
+  echo "Publishing packages to packagecloud ${PACKAGECLOUD_REPOSITORY}"
   echo "--------------------------------------------------"
 
-  REPO="${PACKAGECLOUD_REPOSITORY}"
-  case "${REPO}" in
+  case "${PACKAGECLOUD_REPOSITORY}" in
     dev|test)
       ;;
     *)
-      echo "Invalid packagecloud repository ${REPO} (must be 'dev' or 'test')" >&2
+      echo "Invalid packagecloud repository ${PACKAGECLOUD_REPOSITORY} (must be 'dev' or 'test')" >&2
       exit 1
       ;;
   esac
-  BASE="linz/${REPO}/ubuntu/${dist}"
+  BASE="linz/${PACKAGECLOUD_REPOSITORY}/ubuntu/${dist}"
   if test -n "${DRY_RUN}"; then
     echo "package_cloud push ${BASE} build-area/*.deb (dry-run)"
   else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -249,26 +249,26 @@ if test -n "${GIT_TAG}"; then
       BRANCH=$(echo "${REF}" | sed "s@^remotes/[^/]*/@@")
       echo " Remote branch: ${BRANCH}"
 
-      PUSH_TO=${PUSH_TO_GIT_REMOTE:-${REMOTE_NAME}}
-      echo " Remote to push to: $(printurl ${PUSH_TO})"
-
       if test -z "${REMOTE_NAME}"; then
         continue # something went wrong ?
       fi
 
+      PUSH_TO=${PUSH_TO_GIT_REMOTE:-${REMOTE_NAME}}
+      echo " Remote to push to: $(printurl ${PUSH_TO})"
+
       # Keep note of unique remote names for pushing tag
-      grep -qw "${REMOTE_NAME}" ${REMOTES_FILE} || {
-        echo " Saving remote '$(printurl ${REMOTE_NAME})' to ${REMOTES_FILE}"
-        echo "${REMOTE_NAME}" >> ${REMOTES_FILE}
+      grep -qw "${PUSH_TO}" ${REMOTES_FILE} || {
+        echo " Saving remote '$(printurl ${PUSH_TO})' to ${REMOTES_FILE}"
+        echo "${PUSH_TO}" >> ${REMOTES_FILE}
       }
 
       if test "${BRANCH}" = "HEAD"; then
-        echo " Skipping push to to HEAD of remote $(printurl ${REMOTE_NAME})"
+        echo " Skipping push to remote's HEAD"
         continue
       fi
 
-      echo "  Pushing debian changes to branch ${BRANCH} of remote $(printurl ${REMOTE_NAME})"
-      git push ${GIT_DRY_RUN} "${REMOTE_NAME}" ${TMPBRANCH}:${BRANCH} || exit 1
+      echo "  Pushing debian changes to branch ${BRANCH} of remote $(printurl ${PUSH_TO})"
+      git push ${GIT_DRY_RUN} "${PUSH_TO}" ${TMPBRANCH}:${BRANCH} || exit 1
 
 
     fi # is a remote ref

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -113,7 +113,7 @@ export DEBEMAIL="${LAST_COMMITTER_EMAIL}"
 git config --global user.email "${LAST_COMMITTER_EMAIL}"
 git config --global user.name "${LAST_COMMITTER_NAME}"
 
-msg="New upstream version" #TODO: tweak this (take as param?)
+msg="New version" #TODO: tweak this (take as param?)
 tag=$(git describe --tags --exclude 'debian/*')
 dist=$(lsb_release -cs)
 version="${tag}-linz~${dist}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,14 @@ printurl() {
   fi
 }
 
+redact() {
+  if test -z "$1"; then
+    echo -n;
+  else
+    echo "<redacted>"
+  fi
+}
+
 echo "----------------------------------------------------"
 echo "LINZ Software Packaging system"
 echo 
@@ -25,7 +33,7 @@ echo "      Can be 'test', 'dev' or empty (default)"
 echo "      for not publishing them at all."
 echo "      Targetting 'test' also creates a debian tag"
 echo "      and pushes changes to determined git remote"
-echo "   PACKAGECLOUD_TOKEN"
+echo "   PACKAGECLOUD_TOKEN ["$(redact "${PACKAGECLOUD_TOKEN}")"]"
 echo "      Token to authorize publishing to packagecloud."
 echo "      Only needed if PACKAGECLOUD_REPOSITORY is not empty."
 echo "   PUSH_TO_GIT_REMOTE [$(printurl ${PUSH_TO_GIT_REMOTE})]"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ echo "Supported Arguments:"
 echo "   <srcdir> dir containing source (defaults to /pkg)"
 echo
 echo "Supported Environment Variables:"
-echo "   PUBLISH_TO_REPOSITORY [${PUBLISH_TO_REPOSITORY}]"
+echo "   PACKAGECLOUD_REPOSITORY [${PACKAGECLOUD_REPOSITORY}]"
 echo "      Packagecloud repository to push packages to."
 echo "      Can be 'test', 'dev' or empty (default)"
 echo "      for not publishing them at all."
@@ -27,7 +27,7 @@ echo "      Targetting 'test' also creates a debian tag"
 echo "      and pushes changes to determined git remote"
 echo "   PUSH_TO_GIT_REMOTE [$(printurl ${PUSH_TO_GIT_REMOTE})]"
 echo "      Git remote name or URL to push debian tag and"
-echo "      changes to, if PUBLISH_TO_REPOSITORY=test."
+echo "      changes to, if PACKAGECLOUD_REPOSITORY=test."
 echo "      Defaults to the remotes containing HEAD ref."
 echo "   DRY_RUN [${DRY_RUN}]"
 echo "      Set to non-empty string to avoid publishing any"
@@ -146,7 +146,7 @@ echo "------------------------------"
 echo "Running deb-build-binary"
 echo "------------------------------"
 DEB_BUILD_BINARY_ARGS=
-if test "${PUBLISH_TO_REPOSITORY}" = "test"; then
+if test "${PACKAGECLOUD_REPOSITORY}" = "test"; then
   DEB_BUILD_BINARY_ARGS=--git-tag
 fi
 deb-build-binary ${DEB_BUILD_BINARY_ARGS} > log.deb-build-binary ||
@@ -179,18 +179,18 @@ ls -l build-area/*.deb
 # Check if we need to publish
 #
 
-if test -n "${PUBLISH_TO_REPOSITORY}"; then
+if test -n "${PACKAGECLOUD_REPOSITORY}"; then
 
   echo "--------------------------------------------------"
   echo "Publishing packages to packagecloud ${REPO}"
   echo "--------------------------------------------------"
 
-  REPO="${PUBLISH_TO_REPOSITORY}"
+  REPO="${PACKAGECLOUD_REPOSITORY}"
   case "${REPO}" in
     dev|test)
       ;;
     *)
-      echo "Invalid target linz repository ${REPO} (must be 'dev' or 'test')" >&2
+      echo "Invalid packagecloud repository ${REPO} (must be 'dev' or 'test')" >&2
       exit 1
       ;;
   esac

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -154,6 +154,7 @@ deb-build-binary ${DEB_BUILD_BINARY_ARGS} > log.deb-build-binary ||
   cat log.deb-build-binary;
   exit 1
 }
+cat log.deb-build-binary
 
 # If tags are created, we'd get a message like this:
 #

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -101,8 +101,8 @@ LAST_COMMITTER_EMAIL=$(git --no-pager show -s --format='%ce' HEAD)
 export DEBFULLNAME="${LAST_COMMITTER_NAME}"
 export DEBEMAIL="${LAST_COMMITTER_EMAIL}"
 
-git config --global user.email "${LAST_COMMITTER_NAME}"
-git config --global user.name "${LAST_COMMITTER_EMAIL}"
+git config --global user.email "${LAST_COMMITTER_EMAIL}"
+git config --global user.name "${LAST_COMMITTER_NAME}"
 
 msg="New upstream version" #TODO: tweak this (take as param?)
 tag=$(git describe --tags --exclude 'debian/*')

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -232,10 +232,9 @@ if test -n "${GIT_TAG}"; then
         continue
       fi
 
-      echo "  Merging tag '${GIT_TAG}' to head '${HEAD}'"
-      git checkout "${HEAD}" || exit 1
-      git merge --ff-only "${GIT_TAG}" || exit 1
-      git checkout - || exit 1
+      echo " Merging tag '${GIT_TAG}' to head '${HEAD}'"
+      echo "git push ${GIT_DRY_RUN} . 'refs/tags/${GIT_TAG}':'${HEAD}'"
+      git push ${GIT_DRY_RUN} . "refs/tags/${GIT_TAG}":"${HEAD}" || exit 1
 
     elif expr "$REF" : remotes/ > /dev/null; then
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -108,7 +108,7 @@ msg="New upstream version" #TODO: tweak this (take as param?)
 tag=$(git describe --tags --exclude 'debian/*')
 dist=$(lsb_release -cs)
 debian_revision=1 # TODO: take as parameter ?
-version="${tag}-${debian_revision}linz~${dist}1"
+version="${tag}-${debian_revision}linz~${dist}"
 
 echo "Using version: $version"
 echo "Hostname: ${HOSTNAME}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,6 +54,13 @@ PATH=$PATH:/usr/local/sbin:/usr/sbin:/sbin:
 TMPBRANCH=pkg-dev-${HOSTNAME}
 
 cleanup() {
+  if test -n "${DRY_RUN}" -a -n "${GIT_TAG}"; then
+    echo "--------------------------------------------------"
+    echo "Removing debian tag (dry run)"
+    echo "--------------------------------------------------"
+    git tag -d "${GIT_TAG}"
+  fi
+
   echo "--------------------------------------------------"
   echo "Checking out previous branch"
   echo "--------------------------------------------------"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,6 +53,11 @@ cleanup() {
   echo "Removing temporary branch"
   echo "--------------------------------------------------"
   git branch -D ${TMPBRANCH}
+
+  echo "--------------------------------------------------"
+  echo "Giving ownership of all files to ${REPO_OWNER}"
+  echo "--------------------------------------------------"
+  chown -R ${REPO_OWNER} .
 }
 
 echo "------------------------------"
@@ -74,6 +79,9 @@ echo "------------------------------"
 
 START_HASH=$( git rev-parse HEAD )
 echo "Start hash (rev-parse HEAD): ${START_HASH}"
+
+REPO_OWNER=$('ls' -ld .git | awk '{print $3}')
+echo "Repository owner: ${REPO_OWNER}"
 
 echo "------------------------------"
 echo "Updating Debian changelog"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -107,8 +107,7 @@ git config --global user.name "${LAST_COMMITTER_EMAIL}"
 msg="New upstream version" #TODO: tweak this (take as param?)
 tag=$(git describe --tags --exclude 'debian/*')
 dist=$(lsb_release -cs)
-debian_revision=1 # TODO: take as parameter ?
-version="${tag}-${debian_revision}linz~${dist}"
+version="${tag}-linz~${dist}"
 
 echo "Using version: $version"
 echo "Hostname: ${HOSTNAME}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,7 +39,7 @@ echo "      Only needed if PACKAGECLOUD_REPOSITORY is not empty."
 echo "   PUSH_TO_GIT_REMOTE [$(printurl ${PUSH_TO_GIT_REMOTE})]"
 echo "      Git remote name or URL to push debian tag and"
 echo "      changes to, if PACKAGECLOUD_REPOSITORY=test."
-echo "      Defaults to the remotes containing HEAD ref."
+echo "      Defaults to the remotes pointing at HEAD ref."
 echo "   DRY_RUN [${DRY_RUN}]"
 echo "      Set to non-empty string to avoid publishing any"
 echo "      package and pushing any change/tag to remote."
@@ -236,7 +236,7 @@ if test -n "${GIT_TAG}"; then
   #   remotes/origin/all-remote-branches
   #   heads/all-remote-branches
   #
-  git for-each-ref --contains ${START_HASH} \
+  git for-each-ref --points-at ${START_HASH} \
       --format='%(refname:lstrip=1)' \
       refs/remotes/ refs/heads/ |
   while read -r REF; do
@@ -244,7 +244,7 @@ if test -n "${GIT_TAG}"; then
     if expr "$REF" : heads/ > /dev/null; then
 
       echo "--------------------------------------------------"
-      echo "Head ref containing start hash: ${REF}"
+      echo "Head ref pointing at start hash: ${REF}"
       echo "--------------------------------------------------"
 
       HEAD=$( echo "${REF}" | sed 's@^heads/@@' )
@@ -262,7 +262,7 @@ if test -n "${GIT_TAG}"; then
     elif expr "$REF" : remotes/ > /dev/null; then
 
       echo "--------------------------------------------------"
-      echo "Remote ref containing start hash: ${REF}"
+      echo "Remote ref pointing at start hash: ${REF}"
       echo "--------------------------------------------------"
 
       REMOTE_NAME=$( echo "${REF}" | sed 's@^remotes/\([^/]*\)/.*@\1@' )

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,9 @@ echo "      Can be 'test', 'dev' or empty (default)"
 echo "      for not publishing them at all."
 echo "      Targetting 'test' also creates a debian tag"
 echo "      and pushes changes to determined git remote"
+echo "   PACKAGECLOUD_TOKEN"
+echo "      Token to authorize publishing to packagecloud."
+echo "      Only needed if PACKAGECLOUD_REPOSITORY is not empty."
 echo "   PUSH_TO_GIT_REMOTE [$(printurl ${PUSH_TO_GIT_REMOTE})]"
 echo "      Git remote name or URL to push debian tag and"
 echo "      changes to, if PACKAGECLOUD_REPOSITORY=test."
@@ -206,6 +209,10 @@ if test -n "${PACKAGECLOUD_REPOSITORY}"; then
   fi
 
 fi
+
+#
+# Check if we need to merge changes
+#
 
 if test -n "${GIT_TAG}"; then
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,6 +65,11 @@ PATH=$PATH:/usr/local/sbin:/usr/sbin:/sbin:
 TMPBRANCH=pkg-dev-${HOSTNAME}
 
 cleanup() {
+
+  echo " ----------------"
+  echo "|  CLEANING UP   |"
+  echo " ----------------"
+
   if test -n "${DRY_RUN}" -a -n "${GIT_TAG}"; then
     echo "--------------------------------------------------"
     echo "Removing debian tag (dry run)"


### PR DESCRIPTION
1. Push tag to every found remote rather than just the first one
2. Push debian changes to every remote branch containing original HEAD, rather than just the first one
3. Drop redundant revision AFTER distribution
4. Ensure files are still owned by original owner of .git after local run
5. Support DRY_RUN env variable for easier local tests