### PR TITLE
fix: Avoid duplicate runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [ opened, synchronize ]
+  push:
+    branches:
+      - master
 
 jobs:
 


### PR DESCRIPTION
For example, when pushing to a PR branch that would result in two
events, each of which triggers the build.