### PR TITLE
fix: Don't build for obsolete distros

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,4 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
-    - name: Build default image (bionic)
-      run: make image
-    - name: Build trusty image
-      run: DISTRIBUTION=trusty make image
+    - run: make DISTRIBUTION=bionic image

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 ################################################################################
 
 # Pass via env, like: docker build --build-arg DISTRIBUTION=18.04 ...
-ARG  DISTRIBUTION=bionic
+ARG  DISTRIBUTION
 FROM ubuntu:${DISTRIBUTION}
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-DISTRIBUTION ?= bionic
-
 .PHONY: help
 help:
 	@echo "Available targets:"


### PR DESCRIPTION
We shouldn't use anything older than Ubuntu 18.