### PR TITLE
fix: Specify nixpkgs for `nix-shell`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
           - ubuntu-latest
         distribution:
           - bionic
+    env:
+      NIX_PATH: 'nixpkgs=https://github.com/NixOS/nixpkgs/archive/a7ecde854aee5c4c7cd6177f54a99d2c1ff28a31.tar.gz'
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out repository


### PR DESCRIPTION
Avoids a warning about defaulting to the default Bash shell.