### PR TITLE
feat: Deal with vN tags

### DIFF
--- a/docker-action/bin/deb-build-binary-dist.bash
+++ b/docker-action/bin/deb-build-binary-dist.bash
@@ -18,8 +18,10 @@ buildbranch=pkg-build-dist-$dist-$(date +%s)
 git branch "$buildbranch"
 git checkout "$buildbranch"
 
+last_version_tag="$(git tag --sort=version:refname | grep --invert-match debian | tail --lines=1)"
+version="${last_version_tag#v}"
 dch \
-    --newversion "$(git tag --sort=version:refname | grep -v debian | tail -n 1)-1linz~${dist}1" \
+    --newversion "${version}-1linz~${dist}1" \
     --distribution "$dist" \
     "Package rebuild for $dist"
 

--- a/docker-action/entrypoint.bash
+++ b/docker-action/entrypoint.bash
@@ -126,7 +126,8 @@ git config --global user.email "${last_committer_email}"
 git config --global user.name "${last_committer_name}"
 
 msg="New version"                          #TODO: tweak this (take as param?)
-tag=$(git describe --tags --match '[^d]*') # excluding debian/* tags
+last_version_tag="$(git describe --tags --match '[^d]*')"
+tag="${last_version_tag#v}"
 dist=$(lsb_release -cs)
 version="${tag}-linz~${dist}"
 


### PR DESCRIPTION
This is a workaround for the dummy package in this repo. GitHub action
releases are conventionally tagged vN, but the Debian packaging tools
require a version *number,* so we just strip the "v" from the tag.