### PR TITLE
feat: Install `jq` in builder

### DIFF
--- a/docker-action/Dockerfile
+++ b/docker-action/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
         git \
         git-buildpackage \
         gnupg \
+        jq \
         lsb-release \
         make \
         ruby \


### PR DESCRIPTION
Allows processing JSON files in child package Makefiles.

For https://github.com/linz/postgresql-tableversion/pull/337.