### PR TITLE
fix: Treat /pkg directory as safe

### DIFF
--- a/docker-action/Dockerfile
+++ b/docker-action/Dockerfile
@@ -48,6 +48,8 @@ RUN curl https://packagecloud.io/install/repositories/linz/test/script.deb.sh | 
 RUN curl https://packagecloud.io/install/repositories/linz/prod/script.deb.sh | \
     os=ubuntu dist=focal bash
 
+RUN git config --global --add safe.directory /pkg
+
 COPY Gemfile Gemfile.lock /tmp/
 RUN gem install bundler:2.3.6 \
     && bundle install --gemfile=/tmp/Gemfile


### PR DESCRIPTION
Necessary in recent Git versions to avoid the following error:

> fatal: unsafe repository ('/pkg' is owned by someone else)

A safer solution would be to build the package as the OS user, but with
Docker-in-Docker this is would require a lot of setup.