### PR TITLE
Revert "feat: Build packages on Ubuntu 22.04 (Jammy)"

### DIFF
--- a/docker-action/Dockerfile
+++ b/docker-action/Dockerfile
@@ -44,9 +44,9 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg m
     > /etc/apt/sources.list.d/pgdg.list
 
 RUN curl https://packagecloud.io/install/repositories/linz/test/script.deb.sh | \
-    os=ubuntu dist=jammy bash
+    os=ubuntu dist=focal bash
 RUN curl https://packagecloud.io/install/repositories/linz/prod/script.deb.sh | \
-    os=ubuntu dist=jammy bash
+    os=ubuntu dist=focal bash
 
 RUN git config --global --add safe.directory /pkg
 


### PR DESCRIPTION
This reverts commit 0e02dfe5ded82c2f9a28aa07e68a4aaaed91acd0.

Fixes <https://github.com/linz/linz-software-repository/issues/118>,
caused by <https://github.com/ruby/openssl/issues/369>. Opens
<https://github.com/linz/linz-software-repository/issues/119> for
follow-up.