### PR TITLE
feat: Build packages on Ubuntu 22.04 (Jammy)

### DIFF
--- a/docker-action/Dockerfile
+++ b/docker-action/Dockerfile
@@ -44,9 +44,9 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg m
     > /etc/apt/sources.list.d/pgdg.list
 
 RUN curl https://packagecloud.io/install/repositories/linz/test/script.deb.sh | \
-    os=ubuntu dist=focal bash
+    os=ubuntu dist=jammy bash
 RUN curl https://packagecloud.io/install/repositories/linz/prod/script.deb.sh | \
-    os=ubuntu dist=focal bash
+    os=ubuntu dist=jammy bash
 
 RUN git config --global --add safe.directory /pkg
 


### PR DESCRIPTION
Re-applying since reverting didn't help - the problem is that the platform the script runs on has [too new an SSL version](https://github.com/linz/linz-software-repository/issues/119), not which script is running.