### PR TITLE
build: Drop Ubuntu 18.04 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,12 +26,10 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-          - ubuntu-18.04
           - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-latest
         release:
-          - bionic
           - focal
           - jammy
     env:


### PR DESCRIPTION
After GitHub dropped their runner support
<https://github.com/actions/runner-images/issues/6002>.