### PR TITLE
Revert "fix: Specify nixpkgs for `nix-shell`"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,6 @@ jobs:
         release:
           - focal
           - jammy
-    env:
-      NIX_PATH: 'nixpkgs=https://github.com/NixOS/nixpkgs/archive/a7ecde854aee5c4c7cd6177f54a99d2c1ff28a31.tar.gz'
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out repository


### PR DESCRIPTION
It doesn't seem to be necessary elsewhere, and could possibly influence the build.

This partially reverts commit 8173e9ddc31eea77e7d6e432987152ecc4d1e6f1.